### PR TITLE
fix: thread-safe pipeline for concurrent GPU requests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "whisperx-custom"]
+	path = whisperx-custom
+	url = https://github.com/mardelden/whisperX-custom.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ app/
 | `HF_TOKEN` | (required) | HuggingFace auth token |
 | `PRELOAD_MODEL` | large-v3 | Model to load on startup |
 | `PIPELINE_STRATEGY` | replicate | `replicate` or `split` (ray mode) |
-| `GPU_CONCURRENCY` | 1 | Concurrent GPU runs (simple mode) |
+| `GPU_CONCURRENCY` | 20 | Concurrent GPU runs (simple mode) |
 | `NUM_GPU_REPLICAS` | 1 | Pipeline replicas (ray mode) |
 | `UPLOAD_CHUNK_SIZE_BYTES` | 8388608 | Upload streaming chunk size (8MB) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ curl -F "audio_file=@test.wav" http://localhost:9000/asr
 
 FastAPI service wrapping WhisperX with two serve modes:
 
-**Simple mode** (`SERVE_MODE=simple`, default): Single uvicorn process. Async GPU queue serializes pipeline runs via semaphore + thread pool executor. Good for single GPU / low traffic.
+**Simple mode** (`SERVE_MODE=simple`, default): Single uvicorn process. Async GPU queue runs pipeline in thread pool executor with `GPU_CONCURRENCY` concurrent slots. Per-stage locks in `pipeline.py` serialize access to non-thread-safe stages (transcribe, diarize) while allowing pipeline parallelism — multiple requests can be in different stages simultaneously (e.g., one transcribing while another aligns).
 
 **Ray Serve mode** (`SERVE_MODE=ray`): Cross-request batching with `@serve.batch`. Two strategies:
 - **Replicate** (`PIPELINE_STRATEGY=replicate`, default): Full 3-stage pipeline per GPU replica.
@@ -58,6 +58,7 @@ app/
 ## Key Patterns
 
 - **Thread-safe model loading**: Double-checked locking in `pipeline.py` — check cache, acquire lock, check again, load. Per-model and per-language caching.
+- **Per-stage pipeline locks** (`pipeline.py`): `_transcribe_lock` serializes transcription (upstream WhisperX model mutates shared state), `_diarize_lock` serializes diarization (precautionary). `align()` is stateless and runs lock-free. An in-flight counter ensures `torch.cuda.empty_cache()` only runs when no other request is on the GPU.
 - **Async GPU queue** (`queue.py`): `asyncio.Semaphore` + `ThreadPoolExecutor` keeps event loop responsive while GPU work runs in threads. Configurable via `GPU_CONCURRENCY`.
 - **Graceful degradation**: Alignment and diarization catch exceptions and return partial results rather than failing the request.
 - **Diarization off by default**: Diarization only runs when explicitly requested via `diarize=true` or `enable_diarization=true`.
@@ -71,7 +72,7 @@ app/
 - **HF_TOKEN required**: Diarization needs a HuggingFace token with access to pyannote models. Set via env var or `.env` file.
 - **WhisperX as submodule**: `whisperx-custom/` is a git submodule. Clone with `--recurse-submodules`. Dockerfile and `uv sync` both use the local submodule path.
 - **Version tag must match `app/version.py`**: Currently `0.3.1`. The entrypoint.sh prints this on startup.
-- **GPU memory**: `large-v3` needs ~10GB VRAM. Service clears GPU memory between pipeline stages via `gc.collect()` + `torch.cuda.empty_cache()`.
+- **GPU memory**: `large-v3` needs ~10GB VRAM. Service clears GPU memory between pipeline stages via `gc.collect()` + conditional `torch.cuda.empty_cache()` (skipped when other requests are in-flight).
 - **Shared memory**: Ray mode requires `shm_size: 8g` in docker-compose for Ray object store.
 - **Base image**: `nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04` with PyTorch 2.3.0 + CUDA 12.1 (Docker). Local dev via `uv` uses PyTorch 2.8.0 with cpu/gpu extras.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# WhisperX ASR Service
+
+## Build & Dev Commands
+
+```bash
+# Production (prebuilt image)
+docker compose up -d
+
+# Dev build (local source, live reload)
+docker compose -f docker-compose.dev.yml up --build
+
+# Rebuild after changes
+docker compose -f docker-compose.dev.yml up --build --force-recreate
+
+# Stress test
+python tests/stress_test.py
+
+# Quick test
+curl -F "audio_file=@test.wav" http://localhost:9000/asr
+```
+
+## Architecture
+
+FastAPI service wrapping WhisperX with two serve modes:
+
+**Simple mode** (`SERVE_MODE=simple`, default): Single uvicorn process. Async GPU queue serializes pipeline runs via semaphore + thread pool executor. Good for single GPU / low traffic.
+
+**Ray Serve mode** (`SERVE_MODE=ray`): Cross-request batching with `@serve.batch`. Two strategies:
+- **Replicate** (`PIPELINE_STRATEGY=replicate`, default): Full 3-stage pipeline per GPU replica.
+- **Split** (`PIPELINE_STRATEGY=split`): Each stage as separate Ray deployment with fractional GPU allocation (whisper 0.5, align 0.3, diarize 0.2).
+
+Pipeline: Audio upload → Transcribe (Whisper) → Align (wav2vec2) → Diarize (pyannote) → JSON/SRT/VTT response.
+
+Endpoints: `/asr` (native), `/v1/audio/transcriptions` and `/v1/audio/translations` (OpenAI-compatible), `/health`, `/metrics`.
+
+## Module Structure
+
+```
+app/
+├── __init__.py            # Package init
+├── version.py             # __version__ = "0.3.1"
+├── main.py                # Simple mode FastAPI app, /asr endpoint
+├── pipeline.py            # Shared 3-stage pipeline: transcribe/align/diarize + model caching
+├── queue.py               # Async GPU queue (semaphore + ThreadPoolExecutor)
+├── schemas.py             # Pydantic models (OpenAI-compatible responses)
+├── openai_compat.py       # /v1/audio/* endpoints, model mapping
+├── serve_app.py           # Ray Serve ingress (ASRIngress class)
+└── serve_deployments.py   # Ray Serve deployments (FullPipeline, Whisper, Align, Diarize)
+```
+
+## Key Patterns
+
+- **Thread-safe model loading**: Double-checked locking in `pipeline.py` — check cache, acquire lock, check again, load. Per-model and per-language caching.
+- **Async GPU queue** (`queue.py`): `asyncio.Semaphore` + `ThreadPoolExecutor` keeps event loop responsive while GPU work runs in threads. Configurable via `GPU_CONCURRENCY`.
+- **Graceful degradation**: Alignment and diarization catch exceptions and return partial results rather than failing the request.
+- **Ray Serve batching**: `@serve.batch` on split-mode deployments collects requests up to `max_batch_size` or `batch_wait_timeout_s` (0.1s default).
+- **OpenAI API compatibility**: Model name mapping (whisper-1 → large-v3), response format translation, standard error responses.
+
+## Critical Rules
+
+- **HF_TOKEN required**: Diarization needs a HuggingFace token with access to pyannote models. Set via env var or `.env` file.
+- **WhisperX from local source**: Dockerfile installs WhisperX from sibling `whisperX-custom` repo via `additional_contexts` in docker-compose.dev.yml. No remote fork or sed patch needed.
+- **Version tag must match `app/version.py`**: Currently `0.3.1`. The entrypoint.sh prints this on startup.
+- **GPU memory**: `large-v3` needs ~10GB VRAM. Service clears GPU memory between pipeline stages via `gc.collect()` + `torch.cuda.empty_cache()`.
+- **Shared memory**: Ray mode requires `shm_size: 8g` in docker-compose for Ray object store.
+- **Base image**: `nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04` with PyTorch 2.3.0 + CUDA 12.1.
+
+## Key Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SERVE_MODE` | simple | `simple` or `ray` |
+| `DEVICE` | cuda | `cuda` or `cpu` |
+| `COMPUTE_TYPE` | float16 | `float16`, `float32`, `int8` |
+| `BATCH_SIZE` | 16 | Whisper batch size |
+| `HF_TOKEN` | (required) | HuggingFace auth token |
+| `PRELOAD_MODEL` | large-v3 | Model to load on startup |
+| `PIPELINE_STRATEGY` | replicate | `replicate` or `split` (ray mode) |
+| `GPU_CONCURRENCY` | 1 | Concurrent GPU runs (simple mode) |
+| `NUM_GPU_REPLICAS` | 1 | Pipeline replicas (ray mode) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,12 @@
 ## Build & Dev Commands
 
 ```bash
+# Local dev (uv, CPU)
+uv sync --extra cpu
+
+# Local dev (uv, GPU/CUDA)
+uv sync --extra gpu
+
 # Production (prebuilt image)
 docker compose up -d
 
@@ -63,7 +69,7 @@ app/
 - **Version tag must match `app/version.py`**: Currently `0.3.1`. The entrypoint.sh prints this on startup.
 - **GPU memory**: `large-v3` needs ~10GB VRAM. Service clears GPU memory between pipeline stages via `gc.collect()` + `torch.cuda.empty_cache()`.
 - **Shared memory**: Ray mode requires `shm_size: 8g` in docker-compose for Ray object store.
-- **Base image**: `nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04` with PyTorch 2.3.0 + CUDA 12.1.
+- **Base image**: `nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04` with PyTorch 2.3.0 + CUDA 12.1 (Docker). Local dev via `uv` uses PyTorch 2.8.0 with cpu/gpu extras.
 
 ## Key Environment Variables
 
@@ -78,3 +84,9 @@ app/
 | `PIPELINE_STRATEGY` | replicate | `replicate` or `split` (ray mode) |
 | `GPU_CONCURRENCY` | 1 | Concurrent GPU runs (simple mode) |
 | `NUM_GPU_REPLICAS` | 1 | Pipeline replicas (ray mode) |
+
+## Plans
+
+Implementation plans are stored in `plans/` as numbered markdown files (e.g., `plans/001-feature-name.md`). Reference these for architectural context on past decisions.
+
+Before implementing any plan make sure we capture it in `plans/` through creating new ones or updating existing ones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ app/
 ## Critical Rules
 
 - **HF_TOKEN required**: Diarization needs a HuggingFace token with access to pyannote models. Set via env var or `.env` file.
-- **WhisperX from local source**: Dockerfile installs WhisperX from sibling `whisperX-custom` repo via `additional_contexts` in docker-compose.dev.yml. No remote fork or sed patch needed.
+- **WhisperX as submodule**: `whisperx-custom/` is a git submodule. Clone with `--recurse-submodules`. Dockerfile and `uv sync` both use the local submodule path.
 - **Version tag must match `app/version.py`**: Currently `0.3.1`. The entrypoint.sh prints this on startup.
 - **GPU memory**: `large-v3` needs ~10GB VRAM. Service clears GPU memory between pipeline stages via `gc.collect()` + `torch.cuda.empty_cache()`.
 - **Shared memory**: Ray mode requires `shm_size: 8g` in docker-compose for Ray object store.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ FastAPI service wrapping WhisperX with two serve modes:
 - **Replicate** (`PIPELINE_STRATEGY=replicate`, default): Full 3-stage pipeline per GPU replica.
 - **Split** (`PIPELINE_STRATEGY=split`): Each stage as separate Ray deployment with fractional GPU allocation (whisper 0.5, align 0.3, diarize 0.2).
 
-Pipeline: Audio upload → Transcribe (Whisper) → Align (wav2vec2) → Diarize (pyannote) → JSON/SRT/VTT response.
+Pipeline: Audio upload → Transcribe (Whisper) → Align (wav2vec2) → Diarize (pyannote) → JSON/SRT/VTT/conversation response.
 
 Endpoints: `/asr` (native), `/v1/audio/transcriptions` and `/v1/audio/translations` (OpenAI-compatible), `/health`, `/metrics`.
 
@@ -48,6 +48,7 @@ app/
 ├── main.py                # Simple mode FastAPI app, /asr endpoint
 ├── pipeline.py            # Shared 3-stage pipeline: transcribe/align/diarize + model caching
 ├── queue.py               # Async GPU queue (semaphore + ThreadPoolExecutor)
+├── upload.py              # Streaming file upload utility, FileTooLargeError, size constants
 ├── schemas.py             # Pydantic models (OpenAI-compatible responses)
 ├── openai_compat.py       # /v1/audio/* endpoints, model mapping
 ├── serve_app.py           # Ray Serve ingress (ASRIngress class)
@@ -59,7 +60,10 @@ app/
 - **Thread-safe model loading**: Double-checked locking in `pipeline.py` — check cache, acquire lock, check again, load. Per-model and per-language caching.
 - **Async GPU queue** (`queue.py`): `asyncio.Semaphore` + `ThreadPoolExecutor` keeps event loop responsive while GPU work runs in threads. Configurable via `GPU_CONCURRENCY`.
 - **Graceful degradation**: Alignment and diarization catch exceptions and return partial results rather than failing the request.
+- **Diarization off by default**: Diarization only runs when explicitly requested via `diarize=true` or `enable_diarization=true`.
+- **Conversation output**: `output_format=conversation` merges consecutive segments from the same speaker into conversation turns.
 - **Ray Serve batching**: `@serve.batch` on split-mode deployments collects requests up to `max_batch_size` or `batch_wait_timeout_s` (0.1s default).
+- **Streaming uploads** (`upload.py`): Files are streamed to disk in chunks (default 8MB) to avoid loading entire uploads into memory. Size validated during streaming.
 - **OpenAI API compatibility**: Model name mapping (whisper-1 → large-v3), response format translation, standard error responses.
 
 ## Critical Rules
@@ -84,6 +88,7 @@ app/
 | `PIPELINE_STRATEGY` | replicate | `replicate` or `split` (ray mode) |
 | `GPU_CONCURRENCY` | 1 | Concurrent GPU runs (simple mode) |
 | `NUM_GPU_REPLICAS` | 1 | Pipeline replicas (ray mode) |
+| `UPLOAD_CHUNK_SIZE_BYTES` | 8388608 | Upload streaming chunk size (8MB) |
 
 ## Plans
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,17 +31,9 @@ RUN pip3 install --no-cache-dir \
 # Set library path to prefer PyTorch's bundled cuDNN over system cuDNN
 ENV LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/torch/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib:$LD_LIBRARY_PATH
 
-# Install WhisperX from sealambda's pyannote-audio-4 compatible branch
-# Credit: https://github.com/sealambda/whisperX/tree/feat/pyannote-audio-4
-RUN pip3 install --no-cache-dir git+https://github.com/sealambda/whisperX.git@feat/pyannote-audio-4
-
-# Patch WhisperX diarize.py to use 'token=' instead of 'use_token=' for pyannote.audio 4.0
-# This handles both single-line and multi-line formatting
-RUN sed -i 's/use_token=/token=/g' \
-    /usr/local/lib/python3.10/dist-packages/whisperx/diarize.py
-
-# Install latest pyannote.audio for community-1 model support
-RUN pip3 install --no-cache-dir --upgrade pyannote.audio
+# Install WhisperX from local custom fork (provided via additional_contexts in docker-compose)
+COPY --from=whisperx-custom . /tmp/whisperx-custom
+RUN pip3 install --no-cache-dir /tmp/whisperx-custom && rm -rf /tmp/whisperx-custom
 
 # Install API dependencies
 RUN pip3 install --no-cache-dir \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN pip3 install --no-cache-dir \
 # Set library path to prefer PyTorch's bundled cuDNN over system cuDNN
 ENV LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/torch/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib:$LD_LIBRARY_PATH
 
-# Install WhisperX from local custom fork (provided via additional_contexts in docker-compose)
-COPY --from=whisperx-custom . /tmp/whisperx-custom
+# Install WhisperX from local custom fork (git submodule)
+COPY whisperx-custom /tmp/whisperx-custom
 RUN pip3 install --no-cache-dir /tmp/whisperx-custom && rm -rf /tmp/whisperx-custom
 
 # Install API dependencies

--- a/app/main.py
+++ b/app/main.py
@@ -233,6 +233,32 @@ async def transcribe_audio(
 
             return {"tsv": "\n".join(tsv_content)}
 
+        elif output_format == "conversation":
+            conversation = []
+            current_speaker = None
+            current_text = []
+            for segment in result.get("segments", []):
+                speaker = segment.get("speaker", "Unknown")
+                text = segment.get("text", "").strip()
+                if not text:
+                    continue
+                if speaker == current_speaker:
+                    current_text.append(text)
+                else:
+                    if current_text:
+                        conversation.append({
+                            "speaker": current_speaker,
+                            "text": " ".join(current_text),
+                        })
+                    current_speaker = speaker
+                    current_text = [text]
+            if current_text:
+                conversation.append({
+                    "speaker": current_speaker,
+                    "text": " ".join(current_text),
+                })
+            return JSONResponse(content={"conversation": conversation})
+
         else:
             raise HTTPException(status_code=400, detail=f"Unsupported output format: {output_format}")
 

--- a/app/main.py
+++ b/app/main.py
@@ -127,7 +127,7 @@ async def transcribe_audio(
         if diarize is not None or enable_diarization is not None:
             should_diarize = (diarize is True) or (enable_diarization is True)
         else:
-            should_diarize = True
+            should_diarize = False
         if return_speaker_embeddings is None:
             return_speaker_embeddings = False
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,13 +4,11 @@ Compatible with openai-whisper-asr-webservice API endpoints
 """
 
 import os
-import tempfile
 import logging
 import warnings
 from typing import Optional
-from pathlib import Path
 
-from fastapi import FastAPI, File, UploadFile, Query, HTTPException
+from fastapi import FastAPI, File, UploadFile, Query, HTTPException, Request
 from fastapi.responses import JSONResponse
 import whisperx
 
@@ -29,6 +27,7 @@ from app.pipeline import (
     _whisper_models as loaded_models,
 )
 from app.queue import run_in_queue, get_queue_metrics
+from app.upload import save_upload_to_tempfile, FileTooLargeError
 
 # Suppress pyannote pooling warnings about degrees of freedom
 warnings.filterwarnings("ignore", message=".*degrees of freedom is <= 0.*")
@@ -40,7 +39,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "1000"))
 SERVE_MODE = os.getenv("SERVE_MODE", "simple")
 
 # Initialize FastAPI app
@@ -82,6 +80,7 @@ async def root():
 
 @app.post("/asr")
 async def transcribe_audio(
+    request: Request,
     audio_file: UploadFile = File(...),
     task: str = Query("transcribe"),
     language: Optional[str] = Query(None),
@@ -131,23 +130,14 @@ async def transcribe_audio(
         if return_speaker_embeddings is None:
             return_speaker_embeddings = False
 
-        # Save uploaded file to temporary location
-        with tempfile.NamedTemporaryFile(delete=False, suffix=Path(audio_file.filename).suffix) as temp_file:
-            temp_audio_path = temp_file.name
-            content = await audio_file.read()
-            temp_file.write(content)
-
-        # Check file size
-        file_size_mb = len(content) / (1024 * 1024)
-        if file_size_mb > MAX_FILE_SIZE_MB:
-            raise HTTPException(
-                status_code=413,
-                detail=f"File too large ({file_size_mb:.1f}MB). Maximum allowed: {MAX_FILE_SIZE_MB}MB. "
-                       f"Large files may cause out-of-memory errors."
+        # Stream uploaded file to disk in chunks
+        try:
+            temp_audio_path, file_size_mb = await save_upload_to_tempfile(
+                audio_file,
+                content_length=int(cl) if (cl := request.headers.get("content-length")) else None,
             )
-
-        if file_size_mb > 100:
-            logger.warning(f"Processing large file ({file_size_mb:.1f}MB) - may consume significant VRAM")
+        except FileTooLargeError as e:
+            raise HTTPException(status_code=413, detail=str(e))
 
         logger.info(f"Processing audio file: {audio_file.filename} ({file_size_mb:.1f}MB), model: {model}, language: {language}")
 

--- a/app/openai_compat.py
+++ b/app/openai_compat.py
@@ -6,11 +6,9 @@ GET /v1/models
 """
 
 import os
-import tempfile
 import logging
 import time
 from typing import Optional, List, Union
-from pathlib import Path
 
 from fastapi import APIRouter, File, UploadFile, Form, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -37,10 +35,9 @@ from app.pipeline import (
     _whisper_models as loaded_models,
 )
 from app.queue import run_in_queue
+from app.upload import save_upload_to_tempfile, FileTooLargeError, MAX_FILE_SIZE_MB
 
 logger = logging.getLogger(__name__)
-
-MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "1000"))
 
 router = APIRouter(prefix="/v1/audio", tags=["OpenAI Compatible"])
 models_router = APIRouter(prefix="/v1", tags=["OpenAI Compatible"])
@@ -189,6 +186,7 @@ async def process_audio(
     timestamp_granularities: List[str],
     task: str = "transcribe",
     hotwords: Optional[str] = None,
+    request: Optional[Request] = None,
 ) -> Union[JSONResponse, PlainTextResponse]:
     """
     Core audio processing function shared by transcriptions and translations endpoints
@@ -224,20 +222,18 @@ async def process_audio(
                 param="temperature"
             )
 
-        # Save uploaded file to temporary location
-        suffix = Path(file.filename).suffix if file.filename else ".wav"
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
-            temp_audio_path = temp_file.name
-            content = await file.read()
-            temp_file.write(content)
-
-        # Check file size
-        file_size_mb = len(content) / (1024 * 1024)
-        if file_size_mb > MAX_FILE_SIZE_MB:
+        # Stream uploaded file to disk in chunks
+        cl = request.headers.get("content-length") if request else None
+        try:
+            temp_audio_path, file_size_mb = await save_upload_to_tempfile(
+                file,
+                content_length=int(cl) if cl else None,
+            )
+        except FileTooLargeError:
             return create_openai_error(
                 413,
-                f"File too large ({file_size_mb:.1f}MB). Maximum: {MAX_FILE_SIZE_MB}MB",
-                code="file_too_large"
+                f"File too large. Maximum: {MAX_FILE_SIZE_MB}MB",
+                code="file_too_large",
             )
 
         logger.info(f"OpenAI-compat: Processing {file.filename} ({file_size_mb:.1f}MB), model: {whisperx_model}, task: {task}")
@@ -359,6 +355,7 @@ async def create_transcription(
         timestamp_granularities=timestamp_granularities,
         task="transcribe",
         hotwords=hotwords,
+        request=request,
     )
 
 
@@ -398,6 +395,7 @@ async def create_translation(
         timestamp_granularities=timestamp_granularities,
         task="translate",
         hotwords=hotwords,
+        request=request,
     )
 
 

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -36,6 +36,13 @@ CACHE_DIR = os.getenv("CACHE_DIR", "/.cache")
 DEFAULT_MODEL = os.getenv("PRELOAD_MODEL", "large-v3")
 
 _model_load_lock = threading.Lock()
+_transcribe_lock = threading.Lock()
+_diarize_lock = threading.Lock()
+
+# Track concurrent GPU operations so clear_gpu_memory() only calls
+# torch.cuda.empty_cache() when no other request is using the GPU.
+_gpu_in_flight = 0
+_gpu_in_flight_lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # Model caches
@@ -48,12 +55,35 @@ _diarize_pipeline: Optional[DiarizationPipeline] = None
 # ---------------------------------------------------------------------------
 # GPU helpers
 # ---------------------------------------------------------------------------
+def gpu_in_flight_enter():
+    """Increment the in-flight GPU request counter."""
+    global _gpu_in_flight
+    with _gpu_in_flight_lock:
+        _gpu_in_flight += 1
+
+
+def gpu_in_flight_exit():
+    """Decrement the in-flight GPU request counter."""
+    global _gpu_in_flight
+    with _gpu_in_flight_lock:
+        _gpu_in_flight -= 1
+
+
 def clear_gpu_memory():
-    """Clear GPU memory cache to prevent VRAM buildup."""
+    """Clear GPU memory cache to prevent VRAM buildup.
+
+    Always runs gc.collect(), but only calls torch.cuda.empty_cache() when no
+    other requests are currently using the GPU — avoids disrupting in-flight
+    CUDA operations from concurrent pipeline runs.
+    """
     if DEVICE == "cuda":
         gc.collect()
-        torch.cuda.empty_cache()
-        logger.debug("GPU memory cache cleared")
+        with _gpu_in_flight_lock:
+            if _gpu_in_flight == 0:
+                torch.cuda.empty_cache()
+                logger.debug("GPU memory cache cleared")
+            else:
+                logger.debug("Skipping empty_cache, %d GPU ops in flight", _gpu_in_flight)
 
 
 # ---------------------------------------------------------------------------
@@ -118,30 +148,37 @@ def transcribe(
     initial_prompt: Optional[str] = None,
     hotwords: Optional[str] = None,
 ) -> dict:
-    """Run WhisperX transcription and return raw result dict."""
+    """Run WhisperX transcription and return raw result dict.
+
+    Serialized via _transcribe_lock because the cached model singleton is not
+    thread-safe: per-request options (hotwords, initial_prompt) are mutated on
+    shared state, and upstream FasterWhisperPipeline.transcribe() mutates
+    self.tokenizer and self.options during execution.
+    """
     whisper_model = load_whisper_model(model_name)
 
-    # Set per-request options on the model's transcription options.
-    # The model is cached/shared, so we must reset after transcription.
-    if hotwords is not None:
-        whisper_model.options.hotwords = hotwords
-    if initial_prompt is not None:
-        whisper_model.options.initial_prompt = initial_prompt
-
-    transcribe_options: Dict[str, Any] = {
-        "batch_size": BATCH_SIZE,
-        "language": language,
-        "task": task,
-    }
-
-    logger.info("Starting transcription...")
-    try:
-        result = whisper_model.transcribe(audio, **transcribe_options)
-    finally:
+    with _transcribe_lock:
+        # Set per-request options on the model's transcription options.
+        # The model is cached/shared, so we must reset after transcription.
         if hotwords is not None:
-            whisper_model.options.hotwords = None
+            whisper_model.options.hotwords = hotwords
         if initial_prompt is not None:
-            whisper_model.options.initial_prompt = None
+            whisper_model.options.initial_prompt = initial_prompt
+
+        transcribe_options: Dict[str, Any] = {
+            "batch_size": BATCH_SIZE,
+            "language": language,
+            "task": task,
+        }
+
+        logger.info("Starting transcription...")
+        try:
+            result = whisper_model.transcribe(audio, **transcribe_options)
+        finally:
+            if hotwords is not None:
+                whisper_model.options.hotwords = None
+            if initial_prompt is not None:
+                whisper_model.options.initial_prompt = None
 
     detected_language = result.get("language", language or "en")
     logger.info(f"Transcription complete. Detected language: {detected_language}")
@@ -189,48 +226,52 @@ def diarize(
     Run pyannote speaker diarization and assign speakers to segments.
 
     Returns (result_with_speakers, speaker_embeddings_or_None).
+
+    Serialized via _diarize_lock as a precaution — pyannote internals are
+    not verified thread-safe.
     """
     if not HF_TOKEN:
         logger.warning("Speaker diarization requested but HF_TOKEN not set")
         return result, None
 
-    logger.info("Starting speaker diarization...")
-    speaker_embeddings = None
-    try:
-        diarize_model = load_diarize_pipeline()
+    with _diarize_lock:
+        logger.info("Starting speaker diarization...")
+        speaker_embeddings = None
+        try:
+            diarize_model = load_diarize_pipeline()
 
-        diarize_params: Dict[str, Any] = {}
-        if num_speakers is not None:
-            diarize_params["num_speakers"] = num_speakers
-            logger.info(f"Diarization with exact speaker count: {num_speakers}")
-        else:
-            if min_speakers is not None:
-                diarize_params["min_speakers"] = min_speakers
-            if max_speakers is not None:
-                diarize_params["max_speakers"] = max_speakers
-            logger.info(f"Diarization with speaker range: {min_speakers}-{max_speakers}")
+            diarize_params: Dict[str, Any] = {}
+            if num_speakers is not None:
+                diarize_params["num_speakers"] = num_speakers
+                logger.info(f"Diarization with exact speaker count: {num_speakers}")
+            else:
+                if min_speakers is not None:
+                    diarize_params["min_speakers"] = min_speakers
+                if max_speakers is not None:
+                    diarize_params["max_speakers"] = max_speakers
+                logger.info(f"Diarization with speaker range: {min_speakers}-{max_speakers}")
 
-        if return_speaker_embeddings:
-            diarize_params["return_embeddings"] = True
-            logger.info("Speaker embeddings will be returned")
+            if return_speaker_embeddings:
+                diarize_params["return_embeddings"] = True
+                logger.info("Speaker embeddings will be returned")
 
-        diarize_output = diarize_model(audio, **diarize_params)
+            diarize_output = diarize_model(audio, **diarize_params)
 
-        if return_speaker_embeddings and isinstance(diarize_output, tuple):
-            diarize_segments, speaker_embeddings = diarize_output
-            logger.info(f"Received speaker embeddings for {len(speaker_embeddings)} speakers")
-        else:
-            diarize_segments = diarize_output
+            if return_speaker_embeddings and isinstance(diarize_output, tuple):
+                diarize_segments, speaker_embeddings = diarize_output
+                logger.info(f"Received speaker embeddings for {len(speaker_embeddings)} speakers")
+            else:
+                diarize_segments = diarize_output
 
-        if hasattr(diarize_segments, "exclusive_speaker_diarization"):
-            diarize_segments = diarize_segments.exclusive_speaker_diarization
-            logger.info("Using exclusive speaker diarization for better timestamp reconciliation")
+            if hasattr(diarize_segments, "exclusive_speaker_diarization"):
+                diarize_segments = diarize_segments.exclusive_speaker_diarization
+                logger.info("Using exclusive speaker diarization for better timestamp reconciliation")
 
-        result = whisperx.assign_word_speakers(diarize_segments, result)
-        logger.info("Speaker diarization complete")
-        clear_gpu_memory()
-    except Exception as e:
-        logger.warning(f"Speaker diarization failed: {e}, continuing without diarization")
+            result = whisperx.assign_word_speakers(diarize_segments, result)
+            logger.info("Speaker diarization complete")
+            clear_gpu_memory()
+        except Exception as e:
+            logger.warning(f"Speaker diarization failed: {e}, continuing without diarization")
 
     return result, speaker_embeddings
 
@@ -288,28 +329,35 @@ def run_pipeline(
     Run the full 3-stage pipeline: transcribe -> align -> diarize.
 
     Returns (result, speaker_embeddings_or_None).
+
+    Tracks in-flight GPU operations so clear_gpu_memory() only calls
+    torch.cuda.empty_cache() when no other request is using the GPU.
     """
-    result = transcribe(
-        audio,
-        model_name=model_name,
-        language=language,
-        task=task,
-        initial_prompt=initial_prompt,
-        hotwords=hotwords,
-    )
-
-    if word_timestamps:
-        result = align(audio, result)
-
-    speaker_embeddings = None
-    if should_diarize:
-        result, speaker_embeddings = diarize(
+    gpu_in_flight_enter()
+    try:
+        result = transcribe(
             audio,
-            result,
-            num_speakers=num_speakers,
-            min_speakers=min_speakers,
-            max_speakers=max_speakers,
-            return_speaker_embeddings=return_speaker_embeddings,
+            model_name=model_name,
+            language=language,
+            task=task,
+            initial_prompt=initial_prompt,
+            hotwords=hotwords,
         )
 
-    return result, speaker_embeddings
+        if word_timestamps:
+            result = align(audio, result)
+
+        speaker_embeddings = None
+        if should_diarize:
+            result, speaker_embeddings = diarize(
+                audio,
+                result,
+                num_speakers=num_speakers,
+                min_speakers=min_speakers,
+                max_speakers=max_speakers,
+                return_speaker_embeddings=return_speaker_embeddings,
+            )
+
+        return result, speaker_embeddings
+    finally:
+        gpu_in_flight_exit()

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -101,7 +101,6 @@ def load_diarize_pipeline() -> DiarizationPipeline:
                 logger.info("Loading diarization pipeline: pyannote/speaker-diarization-3.1")
                 _diarize_pipeline = DiarizationPipeline(
                     model_name="pyannote/speaker-diarization-3.1",
-                    use_auth_token=HF_TOKEN,
                     device=torch.device(DEVICE),
                 )
                 logger.info("Diarization pipeline loaded")

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -98,10 +98,10 @@ def load_diarize_pipeline() -> DiarizationPipeline:
     if _diarize_pipeline is None:
         with _model_load_lock:
             if _diarize_pipeline is None:
-                logger.info("Loading diarization pipeline: pyannote/speaker-diarization-community-1")
+                logger.info("Loading diarization pipeline: pyannote/speaker-diarization-3.1")
                 _diarize_pipeline = DiarizationPipeline(
-                    model_name="pyannote/speaker-diarization-community-1",
-                    token=HF_TOKEN,
+                    model_name="pyannote/speaker-diarization-3.1",
+                    use_auth_token=HF_TOKEN,
                     device=torch.device(DEVICE),
                 )
                 logger.info("Diarization pipeline loaded")

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -101,7 +101,7 @@ def load_diarize_pipeline() -> DiarizationPipeline:
                 logger.info("Loading diarization pipeline: pyannote/speaker-diarization-community-1")
                 _diarize_pipeline = DiarizationPipeline(
                     model_name="pyannote/speaker-diarization-community-1",
-                    use_auth_token=HF_TOKEN,
+                    token=HF_TOKEN,
                     device=torch.device(DEVICE),
                 )
                 logger.info("Diarization pipeline loaded")

--- a/app/queue.py
+++ b/app/queue.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Optional
 logger = logging.getLogger(__name__)
 
 MAX_QUEUE_SIZE = int(os.getenv("MAX_QUEUE_SIZE", "32"))
-GPU_CONCURRENCY = int(os.getenv("GPU_CONCURRENCY", "1"))
+GPU_CONCURRENCY = int(os.getenv("GPU_CONCURRENCY", "20"))
 
 # Thread pool for running blocking pipeline calls without blocking the event loop
 _executor = ThreadPoolExecutor(max_workers=GPU_CONCURRENCY)

--- a/app/serve_app.py
+++ b/app/serve_app.py
@@ -524,6 +524,32 @@ class ASRIngress:
                 tsv_content.append(f"{start}\t{end}\t{text}\t{speaker}")
             return {"tsv": "\n".join(tsv_content)}
 
+        elif output_format == "conversation":
+            conversation = []
+            current_speaker = None
+            current_text = []
+            for segment in result.get("segments", []):
+                speaker = segment.get("speaker", "Unknown")
+                text = segment.get("text", "").strip()
+                if not text:
+                    continue
+                if speaker == current_speaker:
+                    current_text.append(text)
+                else:
+                    if current_text:
+                        conversation.append({
+                            "speaker": current_speaker,
+                            "text": " ".join(current_text),
+                        })
+                    current_speaker = speaker
+                    current_text = [text]
+            if current_text:
+                conversation.append({
+                    "speaker": current_speaker,
+                    "text": " ".join(current_text),
+                })
+            return JSONResponse(content={"conversation": conversation})
+
         else:
             raise HTTPException(status_code=400, detail=f"Unsupported output format: {output_format}")
 

--- a/app/serve_app.py
+++ b/app/serve_app.py
@@ -12,10 +12,8 @@ Start with:
 
 import os
 import logging
-import tempfile
 import warnings
 from typing import Optional, List
-from pathlib import Path
 
 from fastapi import FastAPI, File, UploadFile, Form, Query, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -47,6 +45,7 @@ from app.serve_deployments import (
     AlignDeployment,
     DiarizeDeployment,
 )
+from app.upload import save_upload_to_tempfile, FileTooLargeError, MAX_FILE_SIZE_MB
 
 warnings.filterwarnings("ignore", message=".*degrees of freedom is <= 0.*")
 
@@ -55,8 +54,6 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "1000"))
 
 MODEL_MAPPING = {
     "whisper-1": os.getenv("OPENAI_WHISPER1_MODEL", DEFAULT_MODEL),
@@ -148,6 +145,7 @@ class ASRIngress:
     @fastapi_app.post("/asr")
     async def transcribe_audio(
         self,
+        request: Request,
         audio_file: UploadFile = File(...),
         task: str = Query("transcribe"),
         language: Optional[str] = Query(None),
@@ -176,17 +174,13 @@ class ASRIngress:
             if return_speaker_embeddings is None:
                 return_speaker_embeddings = False
 
-            with tempfile.NamedTemporaryFile(delete=False, suffix=Path(audio_file.filename).suffix) as temp_file:
-                temp_audio_path = temp_file.name
-                content = await audio_file.read()
-                temp_file.write(content)
-
-            file_size_mb = len(content) / (1024 * 1024)
-            if file_size_mb > MAX_FILE_SIZE_MB:
-                raise HTTPException(
-                    status_code=413,
-                    detail=f"File too large ({file_size_mb:.1f}MB). Maximum allowed: {MAX_FILE_SIZE_MB}MB.",
+            try:
+                temp_audio_path, file_size_mb = await save_upload_to_tempfile(
+                    audio_file,
+                    content_length=int(cl) if (cl := request.headers.get("content-length")) else None,
                 )
+            except FileTooLargeError as e:
+                raise HTTPException(status_code=413, detail=str(e))
 
             logger.info(f"Processing {audio_file.filename} ({file_size_mb:.1f}MB), model: {model}")
             audio = whisperx.load_audio(temp_audio_path)
@@ -261,7 +255,7 @@ class ASRIngress:
             file=file, model=model, language=language, prompt=prompt,
             response_format=response_format, temperature=temperature,
             timestamp_granularities=timestamp_granularities, task="transcribe",
-            hotwords=hotwords,
+            hotwords=hotwords, request=request,
         )
 
     # ------------------------------------------------------------------
@@ -289,7 +283,7 @@ class ASRIngress:
             file=file, model=model, language=None, prompt=prompt,
             response_format=response_format, temperature=temperature,
             timestamp_granularities=timestamp_granularities, task="translate",
-            hotwords=hotwords,
+            hotwords=hotwords, request=request,
         )
 
     # ------------------------------------------------------------------
@@ -313,6 +307,7 @@ class ASRIngress:
     async def _process_openai_audio(
         self, file, model, language, prompt, response_format,
         temperature, timestamp_granularities, task, hotwords=None,
+        request=None,
     ):
         temp_audio_path = None
         try:
@@ -338,16 +333,15 @@ class ASRIngress:
                 return create_openai_error(400, "temperature must be between 0 and 1",
                                            param="temperature")
 
-            suffix = Path(file.filename).suffix if file.filename else ".wav"
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
-                temp_audio_path = temp_file.name
-                content = await file.read()
-                temp_file.write(content)
-
-            file_size_mb = len(content) / (1024 * 1024)
-            if file_size_mb > MAX_FILE_SIZE_MB:
+            cl = request.headers.get("content-length") if request else None
+            try:
+                temp_audio_path, file_size_mb = await save_upload_to_tempfile(
+                    file,
+                    content_length=int(cl) if cl else None,
+                )
+            except FileTooLargeError:
                 return create_openai_error(
-                    413, f"File too large ({file_size_mb:.1f}MB). Maximum: {MAX_FILE_SIZE_MB}MB",
+                    413, f"File too large. Maximum: {MAX_FILE_SIZE_MB}MB",
                     code="file_too_large",
                 )
 

--- a/app/upload.py
+++ b/app/upload.py
@@ -1,0 +1,94 @@
+"""
+Streaming file upload utility.
+
+Reads uploaded files in chunks to avoid loading the entire file into memory.
+"""
+
+import os
+import tempfile
+import logging
+from typing import Optional
+from pathlib import Path
+
+from fastapi import UploadFile
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "1000"))
+UPLOAD_CHUNK_SIZE_BYTES = int(os.getenv("UPLOAD_CHUNK_SIZE_BYTES", str(8 * 1024 * 1024)))  # 8MB default
+
+
+class FileTooLargeError(Exception):
+    """Raised when an uploaded file exceeds MAX_FILE_SIZE_MB."""
+
+    def __init__(self, file_size_mb: float, max_size_mb: int):
+        self.file_size_mb = file_size_mb
+        self.max_size_mb = max_size_mb
+        super().__init__(
+            f"File too large ({file_size_mb:.1f}MB). Maximum allowed: {max_size_mb}MB. "
+            f"Large files may cause out-of-memory errors."
+        )
+
+
+async def save_upload_to_tempfile(
+    upload_file: UploadFile,
+    content_length: Optional[int] = None,
+) -> tuple[str, float]:
+    """Stream an UploadFile to a temporary file on disk, checking size limits.
+
+    Args:
+        upload_file: The FastAPI UploadFile to save.
+        content_length: Optional Content-Length header value for early rejection.
+
+    Returns:
+        Tuple of (temp_file_path, file_size_mb).
+
+    Raises:
+        FileTooLargeError: If the file exceeds MAX_FILE_SIZE_MB.
+    """
+    max_bytes = MAX_FILE_SIZE_MB * 1024 * 1024
+
+    # Early rejection via Content-Length header (advisory)
+    if content_length is not None and content_length > max_bytes:
+        raise FileTooLargeError(content_length / (1024 * 1024), MAX_FILE_SIZE_MB)
+
+    suffix = Path(upload_file.filename).suffix if upload_file.filename else ".wav"
+    temp_path = None
+
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            temp_path = temp_file.name
+            total_bytes = 0
+
+            while True:
+                chunk = await upload_file.read(UPLOAD_CHUNK_SIZE_BYTES)
+                if not chunk:
+                    break
+                total_bytes += len(chunk)
+                if total_bytes > max_bytes:
+                    raise FileTooLargeError(total_bytes / (1024 * 1024), MAX_FILE_SIZE_MB)
+                temp_file.write(chunk)
+
+        file_size_mb = total_bytes / (1024 * 1024)
+
+        if file_size_mb > 100:
+            logger.warning(f"Processing large file ({file_size_mb:.1f}MB) - may consume significant VRAM")
+
+        return temp_path, file_size_mb
+
+    except FileTooLargeError:
+        # Clean up partial temp file
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        raise
+    except OSError:
+        # Disk full or other I/O error — clean up partial file
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        raise

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      additional_contexts:
+        - whisperx-custom=../whisperX-custom
 
     container_name: whisperx-asr-api-dev
     restart: unless-stopped

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      additional_contexts:
-        - whisperx-custom=../whisperX-custom
 
     container_name: whisperx-asr-api-dev
     restart: unless-stopped

--- a/plans/001-streaming-file-uploads.md
+++ b/plans/001-streaming-file-uploads.md
@@ -1,0 +1,21 @@
+# Plan 001: Streaming File Uploads to Avoid Memory Exhaustion
+
+**Status:** Implemented
+
+## Problem
+
+All upload entry points called `await audio_file.read()` loading entire files into RAM before writing to disk. With 1GB+ file limits, each in-flight request consumed 1GB+ of RAM just for the upload step.
+
+## Solution
+
+Created `app/upload.py` with `save_upload_to_tempfile()` that streams uploads to disk in configurable chunks (default 8MB via `UPLOAD_CHUNK_SIZE_BYTES`). Size is validated during streaming, aborting early if `MAX_FILE_SIZE_MB` is exceeded.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `app/upload.py` | **NEW** — `save_upload_to_tempfile()`, `FileTooLargeError`, centralized `MAX_FILE_SIZE_MB` and `UPLOAD_CHUNK_SIZE_BYTES` |
+| `app/main.py` | Replaced in-memory upload with streaming, removed local `MAX_FILE_SIZE_MB`, added `Request` param |
+| `app/openai_compat.py` | Replaced in-memory upload with streaming, removed local `MAX_FILE_SIZE_MB`, added `request` param to `process_audio()` |
+| `app/serve_app.py` | Replaced both upload blocks with streaming, removed local `MAX_FILE_SIZE_MB`, added `request` params |
+| `CLAUDE.md` | Added `upload.py` to module structure, `UPLOAD_CHUNK_SIZE_BYTES` to env var table |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "whisperx-asr-service"
 version = "0.3.1"
 description = "FastAPI service wrapping WhisperX for ASR, alignment, and diarization"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.10, <3.13"
 
 dependencies = [
     "fastapi==0.104.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ dependencies = [
     "uvicorn[standard]==0.24.0",
     "python-multipart==0.0.6",
     "pydantic==2.5.0",
-    "whisperx @ file:///${PROJECT_ROOT}/../whisperX-custom",
+    "whisperx",
+]
+
+[project.optional-dependencies]
+gpu = [
+    "whisperx[gpu]",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cpu = [
+    "whisperx[cpu]",
+]
 gpu = [
     "whisperx[gpu]",
+]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cpu" },
+        { extra = "gpu" },
+    ],
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,14 @@ dependencies = [
 [project.optional-dependencies]
 cpu = [
     "whisperx[cpu]",
+    "torch~=2.8.0",
+    "torchaudio~=2.8.0",
 ]
 gpu = [
     "whisperx[gpu]",
+    "torch~=2.8.0",
+    "torchaudio~=2.8.0",
+    "triton>=3.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
 [tool.uv]
@@ -30,3 +35,24 @@ conflicts = [
 
 [tool.uv.sources]
 whisperx = { path = "../whisperX-custom", editable = true }
+torch = [
+  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cpu", extra = "cpu" },
+]
+torchaudio = [
+  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cpu", extra = "cpu" },
+]
+triton = [
+  { index = "pytorch-cu130", extra = "gpu" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,22 +13,36 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gpu = []
+cpu = [
+    "torch~=2.8.0",
+    "torchaudio~=2.8.0",
+]
+gpu = [
+    "torch~=2.8.0",
+    "torchaudio~=2.8.0",
+    "triton>=3.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
+[tool.uv]
+conflicts = [
+    [
+        { extra = "cpu" },
+        { extra = "gpu" },
+    ],
+]
 
 [tool.uv.sources]
 whisperx = { path = "./whisperx-custom", editable = true }
 torch = [
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
-  { index = "pytorch-cu130", marker = "sys_platform != 'darwin' and platform_machine == 'x86_64'" },
-  { index = "pytorch-cpu", marker = "sys_platform != 'darwin' and platform_machine != 'x86_64'" },
+  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cpu", extra = "cpu" },
 ]
 torchaudio = [
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
-  { index = "pytorch-cu130", marker = "sys_platform != 'darwin' and platform_machine == 'x86_64'" },
-  { index = "pytorch-cpu", marker = "sys_platform != 'darwin' and platform_machine != 'x86_64'" },
+  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cpu", extra = "cpu" },
 ]
 triton = [
-  { index = "pytorch-cu130", marker = "sys_platform == 'linux'" },
+  { index = "pytorch-cu130", extra = "gpu" },
 ]
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,20 +34,20 @@ conflicts = [
 [tool.uv.sources]
 whisperx = { path = "./whisperx-custom", editable = true }
 torch = [
-  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cu128", extra = "gpu" },
   { index = "pytorch-cpu", extra = "cpu" },
 ]
 torchaudio = [
-  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cu128", extra = "gpu" },
   { index = "pytorch-cpu", extra = "cpu" },
 ]
 triton = [
-  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cu128", extra = "gpu" },
 ]
 
 [[tool.uv.index]]
-name = "pytorch-cu130"
-url = "https://download.pytorch.org/whl/cu130"
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,38 +13,22 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cpu = [
-    "whisperx[cpu]",
-    "torch~=2.8.0",
-    "torchaudio~=2.8.0",
-]
-gpu = [
-    "whisperx[gpu]",
-    "torch~=2.8.0",
-    "torchaudio~=2.8.0",
-    "triton>=3.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
-]
-
-[tool.uv]
-conflicts = [
-    [
-        { extra = "cpu" },
-        { extra = "gpu" },
-    ],
-]
+gpu = []
 
 [tool.uv.sources]
-whisperx = { path = "../whisperX-custom", editable = true }
+whisperx = { path = "./whisperx-custom", editable = true }
 torch = [
-  { index = "pytorch-cu130", extra = "gpu" },
-  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-cu130", marker = "sys_platform != 'darwin' and platform_machine == 'x86_64'" },
+  { index = "pytorch-cpu", marker = "sys_platform != 'darwin' and platform_machine != 'x86_64'" },
 ]
 torchaudio = [
-  { index = "pytorch-cu130", extra = "gpu" },
-  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
+  { index = "pytorch-cu130", marker = "sys_platform != 'darwin' and platform_machine == 'x86_64'" },
+  { index = "pytorch-cpu", marker = "sys_platform != 'darwin' and platform_machine != 'x86_64'" },
 ]
 triton = [
-  { index = "pytorch-cu130", extra = "gpu" },
+  { index = "pytorch-cu130", marker = "sys_platform == 'linux'" },
 ]
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "whisperx-asr-service"
+version = "0.3.1"
+description = "FastAPI service wrapping WhisperX for ASR, alignment, and diarization"
+requires-python = ">=3.9, <3.14"
+
+dependencies = [
+    "fastapi==0.104.1",
+    "uvicorn[standard]==0.24.0",
+    "python-multipart==0.0.6",
+    "pydantic==2.5.0",
+    "whisperx @ file:///${PROJECT_ROOT}/../whisperX-custom",
+]
+
+[tool.uv.sources]
+whisperx = { path = "../whisperX-custom", editable = true }


### PR DESCRIPTION
## Summary

- Add per-stage locks (`_transcribe_lock`, `_diarize_lock`) to serialize access to non-thread-safe pipeline stages when `GPU_CONCURRENCY > 1`
- `transcribe()` is serialized because the cached WhisperX model mutates shared state (`hotwords`, `initial_prompt`, `self.tokenizer`, `self.options`) during execution
- `diarize()` is serialized as a precaution (pyannote internals not verified thread-safe)
- `align()` remains lock-free — confirmed stateless and thread-safe
- Add in-flight GPU counter so `torch.cuda.empty_cache()` only runs when no other request is on the GPU, preventing disruption of concurrent CUDA operations
- Multiple requests can still be in **different** pipeline stages simultaneously (pipeline parallelism)

## Test plan

- [ ] Verify `python -c "import app.pipeline; print(hasattr(app.pipeline, '_transcribe_lock'))"` → `True`
- [ ] Two concurrent `/asr` requests should both complete without 500 errors
- [ ] Stress test (`python tests/stress_test.py`) still passes
- [ ] Check logs: overlapping requests show pipeline parallelism (one transcribing while another aligns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)