### PR TITLE
fix(build): upgrade environment to CUDA 13.1 and PyTorch 2.12 for DGX Spark support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,17 @@
 #                     Pascal/Volta/Turing/Ampere/Hopper). For Blackwell
 #                     (RTX 50xx) use TORCH_VERSION=2.8.0 with cu128. CUDA
 #                     12.8 dropped Pascal/Maxwell support per upstream.
-ARG TORCH_VERSION=2.7.1
-ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu126
+ARG TORCH_VERSION=2.12.0+cu130
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu130
 
-FROM nvidia/cuda:12.3.2-cudnn9-devel-ubuntu22.04
+FROM --platform=linux/arm64 nvidia/cuda:13.1.2-cudnn-devel-ubuntu22.04
 
 # Re-declare ARGs after FROM so they're visible inside the build stage.
 ARG TORCH_VERSION
 ARG TORCH_INDEX_URL
+
+# DGX Spark (GB10)
+ENV TORCH_CUDA_ARCH_LIST="12.1"
 
 # Prevent interactive prompts during build
 ENV DEBIAN_FRONTEND=noninteractive
@@ -31,6 +34,8 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     git \
     wget \
+    cmake \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip
@@ -41,7 +46,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 # we re-pin to ${TORCH_VERSION} after that step so the requested version sticks.
 RUN pip3 install --no-cache-dir \
     torch==${TORCH_VERSION} \
-    torchaudio==${TORCH_VERSION} \
+    torchaudio==2.11.0+cu130 \
     --index-url ${TORCH_INDEX_URL}
 
 # Set library path to prefer PyTorch's bundled cuDNN over system cuDNN
@@ -56,6 +61,24 @@ RUN pip3 install --no-cache-dir git+https://github.com/sealambda/whisperX.git@fe
 RUN sed -i 's/use_token=/token=/g' \
     /usr/local/lib/python3.10/dist-packages/whisperx/diarize.py
 
+# Compiling CTranslate2 from source, bypassing Blackwell architecture parser error in CMake
+RUN pip3 uninstall -y ctranslate2 && \
+    git clone --recursive https://github.com/OpenNMT/CTranslate2.git /tmp/ctranslate2 && \
+    cd /tmp/ctranslate2 && \
+    # Hotfix: Hardcoding sm_121 right after the flag generation function
+    sed -i '/cuda_select_nvcc_arch_flags(ARCH_FLAGS ${CUDA_ARCH_LIST})/a \    list(APPEND ARCH_FLAGS "-gencode;arch=compute_121,code=sm_121")' CMakeLists.txt && \
+    # Remove old architectures incompatible with CUDA 13 from the default fallback list
+    sed -i 's/"3.5;5.0;5.3;6.0;6.1;7.0;7.5;8.0;8.6;8.6+PTX"/"9.0;9.0+PTX"/' CMakeLists.txt 2>/dev/null || true && \
+    mkdir build && cd build && \
+    cmake -DWITH_CUDA=ON \
+          -DCUDA_ARCH_LIST="9.0" \
+          -DWITH_MKL=OFF \
+          -DOPENMP_RUNTIME=COMP .. && \
+    make -j$(nproc) install && \
+    cd ../python && \
+    pip3 install --no-cache-dir . && \
+    rm -rf /tmp/ctranslate2
+
 # Install latest pyannote.audio for community-1 model support
 RUN pip3 install --no-cache-dir --upgrade pyannote.audio
 
@@ -65,7 +88,7 @@ RUN pip3 install --no-cache-dir --upgrade pyannote.audio
 # image variant being built (cu126/2.7.1 default; cu128/2.8.0 for Blackwell).
 RUN pip3 install --no-cache-dir \
     torch==${TORCH_VERSION} \
-    torchaudio==${TORCH_VERSION} \
+    torchaudio==2.11.0+cu130 \
     --index-url ${TORCH_INDEX_URL}
 
 # Install API dependencies


### PR DESCRIPTION
- Updated base image to nvidia/cuda:13.1.2-cudnn-devel-ubuntu22.04
- Upgraded PyTorch to v2.12.0+cu130 and torchaudio to v2.11.0+cu130 to resolve ARM64 nvrtc parsing errors
- Fixed CTranslate2 build by patching CMakeLists.txt to force build for sm_121 architecture and bypass broken auto-detection
- Tested only on DGX Spark. Works with murtaza-nasir/speakr