### PR TITLE
Pin app logger to INFO under uvicorn's logging config

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,9 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
+# uvicorn applies logging.config.dictConfig() before our basicConfig runs,
+# so set the "app" namespace level explicitly here.
+logging.getLogger("app").setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
 
 MAX_FILE_SIZE_MB = int(os.getenv("MAX_FILE_SIZE_MB", "1000"))


### PR DESCRIPTION
uvicorn runs logging.config.dictConfig() before main.py's basicConfig, so the
`app` logger keeps its default level and INFO records get dropped.

- Set the `app` logger to INFO explicitly, matching what serve_deployments.py
  already does for the Ray path.
- Three-line change in app/main.py.
- Verified by reproducing uvicorn's config order: the `app` logger resolves to
  INFO with the change and stays at the dictConfig default without it.

Assisted by Claude Code, human-reviewed.
