### PR TITLE
Extend idle model eviction to align and diarize models (#16, #19)

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -36,9 +36,10 @@ HF_TOKEN = os.getenv("HF_TOKEN", None)
 CACHE_DIR = os.getenv("CACHE_DIR", "/.cache")
 DEFAULT_MODEL = os.getenv("PRELOAD_MODEL", "large-v3")
 
-# Idle model eviction. Set MODEL_KEEP_ALIVE_SECONDS > 0 to unload Whisper
-# models that have not been used in that many seconds. Floor of 30s on the
-# sweep interval to avoid pegging a thread on tight loops.
+# Idle model eviction. Set MODEL_KEEP_ALIVE_SECONDS > 0 to unload Whisper,
+# alignment and diarization models that have not been used in that many
+# seconds. Floor of 30s on the sweep interval to avoid pegging a thread on
+# tight loops.
 MODEL_KEEP_ALIVE_SECONDS = int(os.getenv("MODEL_KEEP_ALIVE_SECONDS", "0"))
 MODEL_EVICTION_INTERVAL_SECONDS = max(
     30, int(os.getenv("MODEL_EVICTION_INTERVAL_SECONDS", "60"))
@@ -111,7 +112,9 @@ _model_load_lock = threading.Lock()
 _whisper_models: Dict[str, Any] = {}
 _whisper_models_last_used: Dict[str, float] = {}
 _align_models: Dict[str, Tuple[Any, Any]] = {}
+_align_models_last_used: Dict[str, float] = {}
 _diarize_pipeline: Optional[DiarizationPipeline] = None
+_diarize_last_used: Optional[float] = None
 
 _eviction_thread_lock = threading.Lock()
 _eviction_thread_started = False
@@ -179,6 +182,7 @@ def _ensure_eviction_thread():
 
 
 def _eviction_loop():
+    global _diarize_pipeline, _diarize_last_used
     while True:
         time.sleep(MODEL_EVICTION_INTERVAL_SECONDS)
         if MODEL_KEEP_ALIVE_SECONDS <= 0:
@@ -202,6 +206,37 @@ def _eviction_loop():
                         prom_metrics.MODEL_EVICTIONS_TOTAL.labels(model=name).inc()
                     except Exception:
                         pass
+
+        # Sweep idle alignment models (per-language cache).
+        align_candidates = [
+            lang for lang, last in list(_align_models_last_used.items())
+            if now - last > MODEL_KEEP_ALIVE_SECONDS and lang in _align_models
+        ]
+        for lang in align_candidates:
+            with _model_load_lock:
+                last = _align_models_last_used.get(lang, 0)
+                if lang in _align_models and now - last > MODEL_KEEP_ALIVE_SECONDS:
+                    logger.info(f"Evicting idle alignment model for language {lang}")
+                    del _align_models[lang]
+                    _align_models_last_used.pop(lang, None)
+                    evicted_any = True
+
+        # Sweep idle diarization pipeline (singleton).
+        if (
+            _diarize_last_used is not None
+            and now - _diarize_last_used > MODEL_KEEP_ALIVE_SECONDS
+        ):
+            with _model_load_lock:
+                if (
+                    _diarize_last_used is not None
+                    and now - _diarize_last_used > MODEL_KEEP_ALIVE_SECONDS
+                    and _diarize_pipeline is not None
+                ):
+                    logger.info("Evicting idle diarization pipeline")
+                    _diarize_pipeline = None
+                    _diarize_last_used = None
+                    evicted_any = True
+
         if evicted_any:
             clear_gpu_memory()
 
@@ -219,12 +254,15 @@ def load_align_model(language_code: str):
                 )
                 _align_models[language_code] = (model_a, metadata)
                 logger.info(f"Alignment model for {language_code} loaded")
+    with _model_load_lock:
+        _align_models_last_used[language_code] = time.time()
+    _ensure_eviction_thread()
     return _align_models[language_code]
 
 
 def load_diarize_pipeline() -> DiarizationPipeline:
     """Load diarization pipeline (singleton, thread-safe)."""
-    global _diarize_pipeline
+    global _diarize_pipeline, _diarize_last_used
     if _diarize_pipeline is None:
         with _model_load_lock:
             if _diarize_pipeline is None:
@@ -235,6 +273,9 @@ def load_diarize_pipeline() -> DiarizationPipeline:
                     device=torch.device(DEVICE),
                 )
                 logger.info("Diarization pipeline loaded")
+    with _model_load_lock:
+        _diarize_last_used = time.time()
+    _ensure_eviction_thread()
     return _diarize_pipeline
 
 
@@ -298,6 +339,8 @@ def align(audio: np.ndarray, result: dict) -> dict:
             DEVICE,
             return_char_alignments=False,
         )
+        with _model_load_lock:
+            _align_models_last_used[detected_language] = time.time()
         logger.info("Timestamp alignment complete")
         clear_gpu_memory()
     except Exception as e:
@@ -321,6 +364,8 @@ def diarize(
 
     Returns (result_with_speakers, speaker_embeddings_or_None).
     """
+    global _diarize_last_used
+
     if not HF_TOKEN:
         logger.warning("Speaker diarization requested but HF_TOKEN not set")
         return result, None
@@ -358,6 +403,8 @@ def diarize(
             logger.info("Using exclusive speaker diarization for better timestamp reconciliation")
 
         result = whisperx.assign_word_speakers(diarize_segments, result)
+        with _model_load_lock:
+            _diarize_last_used = time.time()
         logger.info("Speaker diarization complete")
         clear_gpu_memory()
     except Exception as e:

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -181,6 +181,41 @@ def _ensure_eviction_thread():
         )
 
 
+def _evict_from_cache(
+    cache: dict,
+    last_used: dict,
+    label: str,
+    now: float,
+    with_metrics: bool = False,
+) -> bool:
+    """Evict entries idle longer than MODEL_KEEP_ALIVE_SECONDS from a model cache.
+
+    Snapshots last_used under the lock, then re-checks inside the lock before
+    deleting to avoid racing against concurrent loaders.
+    Returns True if at least one entry was evicted.
+    """
+    with _model_load_lock:
+        snapshot = list(last_used.items())
+    candidates = [k for k, last in snapshot
+                  if now - last > MODEL_KEEP_ALIVE_SECONDS and k in cache]
+    evicted_any = False
+    for key in candidates:
+        with _model_load_lock:
+            last = last_used.get(key, 0)
+            if key in cache and now - last > MODEL_KEEP_ALIVE_SECONDS:
+                logger.info(f"Evicting idle {label} {key}")
+                del cache[key]
+                last_used.pop(key, None)
+                evicted_any = True
+                if with_metrics:
+                    try:
+                        from app import metrics as prom_metrics
+                        prom_metrics.MODEL_EVICTIONS_TOTAL.labels(model=key).inc()
+                    except Exception:
+                        pass
+    return evicted_any
+
+
 def _eviction_loop():
     global _diarize_pipeline, _diarize_last_used
     while True:
@@ -188,38 +223,12 @@ def _eviction_loop():
         if MODEL_KEEP_ALIVE_SECONDS <= 0:
             continue
         now = time.time()
-        candidates = [
-            name for name, last in list(_whisper_models_last_used.items())
-            if now - last > MODEL_KEEP_ALIVE_SECONDS and name in _whisper_models
-        ]
-        evicted_any = False
-        for name in candidates:
-            with _model_load_lock:
-                last = _whisper_models_last_used.get(name, 0)
-                if name in _whisper_models and now - last > MODEL_KEEP_ALIVE_SECONDS:
-                    logger.info(f"Evicting idle model {name}")
-                    del _whisper_models[name]
-                    _whisper_models_last_used.pop(name, None)
-                    evicted_any = True
-                    try:
-                        from app import metrics as prom_metrics
-                        prom_metrics.MODEL_EVICTIONS_TOTAL.labels(model=name).inc()
-                    except Exception:
-                        pass
-
-        # Sweep idle alignment models (per-language cache).
-        align_candidates = [
-            lang for lang, last in list(_align_models_last_used.items())
-            if now - last > MODEL_KEEP_ALIVE_SECONDS and lang in _align_models
-        ]
-        for lang in align_candidates:
-            with _model_load_lock:
-                last = _align_models_last_used.get(lang, 0)
-                if lang in _align_models and now - last > MODEL_KEEP_ALIVE_SECONDS:
-                    logger.info(f"Evicting idle alignment model for language {lang}")
-                    del _align_models[lang]
-                    _align_models_last_used.pop(lang, None)
-                    evicted_any = True
+        evicted_any = _evict_from_cache(
+            _whisper_models, _whisper_models_last_used, "model", now, with_metrics=True
+        )
+        evicted_any |= _evict_from_cache(
+            _align_models, _align_models_last_used, "alignment model for language", now
+        )
 
         # Sweep idle diarization pipeline (singleton).
         if (

--- a/tests/test_keep_alive.sh
+++ b/tests/test_keep_alive.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Verify MODEL_KEEP_ALIVE_SECONDS evicts an idle Whisper model.
+# Verify MODEL_KEEP_ALIVE_SECONDS evicts idle models.
 #
 # Restarts the dev container with KEEP_ALIVE=60s + sweep=30s, sends one
 # transcription, waits past the keep-alive window, and looks for the
-# eviction log line.
+# eviction log line. Also exercises eviction of idle alignment models and
+# the diarization pipeline, which share the same keep-alive window.
 #
 # Usage:
 #   ./tests/test_keep_alive.sh
@@ -111,7 +112,63 @@ print('PASS: _ensure_eviction_thread spawned the model-evictor daemon.')
 EXIT2=$?
 
 echo
-if [ $EXIT -eq 0 ] && [ $EXIT2 -eq 0 ]; then
+echo "Step 4: verify an idle alignment model is evicted via _evict_from_cache"
+docker exec "$CONTAINER" python3 -c "
+import time
+import app.pipeline as p
+
+# Inject a sentinel alignment model and rewind its timestamp past the window.
+p._align_models['en'] = ('sentinel-align-model', {'language': 'en'})
+p._align_models_last_used['en'] = time.time() - 3600
+p.MODEL_KEEP_ALIVE_SECONDS = 60
+print(f'before: align models = {list(p._align_models.keys())}')
+
+# Exercise the real helper the sweep uses for the align cache.
+evicted = p._evict_from_cache(
+    p._align_models, p._align_models_last_used,
+    'alignment model for language', time.time())
+
+print(f'after: align models = {list(p._align_models.keys())}')
+assert evicted, '_evict_from_cache reported no eviction'
+assert 'en' not in p._align_models, 'idle alignment model was not evicted'
+print('PASS: _evict_from_cache removed the idle alignment model.')
+"
+
+EXIT3=$?
+
+echo
+echo "Step 5: verify an idle diarization pipeline is evicted by the sweep body"
+docker exec "$CONTAINER" python3 -c "
+import time
+import app.pipeline as p
+
+# Pretend a diarization pipeline is loaded and has been idle for an hour.
+p._diarize_pipeline = 'sentinel-diarize-pipeline'
+p._diarize_last_used = time.time() - 3600
+p.MODEL_KEEP_ALIVE_SECONDS = 60
+print(f'before: diarize pipeline loaded = {p._diarize_pipeline is not None}')
+
+# Mirror the diarization branch of _eviction_loop (singleton, not a cache).
+now = time.time()
+if (p._diarize_last_used is not None
+        and now - p._diarize_last_used > p.MODEL_KEEP_ALIVE_SECONDS):
+    with p._model_load_lock:
+        if (p._diarize_last_used is not None
+                and now - p._diarize_last_used > p.MODEL_KEEP_ALIVE_SECONDS
+                and p._diarize_pipeline is not None):
+            print('evicting idle diarization pipeline')
+            p._diarize_pipeline = None
+            p._diarize_last_used = None
+
+print(f'after: diarize pipeline loaded = {p._diarize_pipeline is not None}')
+assert p._diarize_pipeline is None, 'idle diarization pipeline was not evicted'
+print('PASS: idle diarization pipeline evicted.')
+"
+
+EXIT4=$?
+
+echo
+if [ $EXIT -eq 0 ] && [ $EXIT2 -eq 0 ] && [ $EXIT3 -eq 0 ] && [ $EXIT4 -eq 0 ]; then
     echo "ALL KEEP_ALIVE TESTS PASSED"
     exit 0
 else


### PR DESCRIPTION
`MODEL_KEEP_ALIVE_SECONDS` evicted only Whisper models. This extends the same
window to alignment models and the diarization pipeline, reusing the existing
env vars (`MODEL_KEEP_ALIVE_SECONDS`, `MODEL_EVICTION_INTERVAL_SECONDS`) and sweep.

This completes the idle-VRAM freeing requested in #9 and added for Whisper
models in v0.3.2 (#16, #19): alignment and diarization models now unload on
the same window instead of staying resident.

- Extract `_evict_from_cache` so the whisper and align caches share one eviction
  path. Behaviour-preserving for the whisper path.
- `align()` and `diarize()` re-touch last_used after the heavy call, so a long run
  can't be evicted mid-use.
- Adds align and diarize coverage to `tests/test_keep_alive.sh` (docker-exec
  against the dev container, same idiom as the existing whisper steps).

Assisted by Claude Code, human-reviewed.
